### PR TITLE
DB設計の更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,9 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|payment_card_no|string|null:false|
-|payment_card_expire_mm|integer|null: false|
-|payment_card_expire_yy|integer|null: false|
-|payment_card_security_code|string|null: false|
 |user_id|integer|null: false, foreign_key: true|
+|customer_id|string|null:false|
+|card_token|string|null: false|
 
 ### Association
 - belongs_to :user
@@ -74,7 +72,8 @@
 |shipping_from_area|string|null:false|
 |shipping_duration|string|null:false|
 |price|string|null:false|
-|user_id|integer|null:false, foreign_key: true|
+|seller_id|integer|null:false, foreign_key: true|
+|buyer_id|integer|foreign_key: true|
 
 ### Association
 - belongs_to :user


### PR DESCRIPTION
# What
第1回のスプリントレビューで指摘があった下記内容を更新する。
①itemsテーブルのuser_idをseller_id、buyer_idに変更
②cardsテーブルをpay.jp仕様に変更

# Why
①itemsテーブルのuser_idをseller_id、buyer_idに変更
商品購入の際に、商品に購入者の紐付けができるようにする必要がある。

②cardsテーブルをpay.jp仕様に変更
クレジットカード情報をDBに保存することはセキュリティ上危険。
pay.jpというサービスを使用する為、cardsテーブルをpay.jpの仕様に合わせる必要がある。

