### PR TITLE
商品出品ページのカテゴリ表示の実装

### DIFF
--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -1,0 +1,77 @@
+$(function(){
+  // カテゴリーセレクトボックスのオプションを作成
+  function appendOption(category){
+    var html = `<option value="${category.id}">${category.name}</option>`;
+    return html;
+  }
+  // 子カテゴリーの表示作成
+  function appendChidrenBox(insertHTML){
+    var childSelectHtml = '';
+    childSelectHtml =  `<select id="child_category", class="category", name="item[category_id]">
+                          ${insertHTML}
+                        </select>`;
+    $('#category_area').append(childSelectHtml);
+  }
+  // 孫カテゴリーの表示作成
+  function appendGrandchidrenBox(insertHTML){
+    var grandchildSelectHtml = '';
+    grandchildSelectHtml = `<select id="grandchild_category", class="category" name="item[category_id]">
+                              ${insertHTML}
+                            </select>`;
+    $('#category_area').append(grandchildSelectHtml);
+  }
+  // 親カテゴリー選択後のイベント
+  $('#item_category_id').on('change', function(){
+    var parentCategory = document.getElementById('item_category_id').value; //選択された親カテゴリーの名前を取得
+    $('#child_category').remove(); //親が変更された時、子以下を削除する
+    $('#grandchild_category').remove();
+    if (parentCategory != "選択してください"){ //親カテゴリーが初期値でないことを確認
+      $.ajax({
+        url: 'get_category_children',
+        type: 'GET',
+        data: { parent_id: parentCategory },
+        dataType: 'json'
+      })
+      .done(function(children){
+        var insertHTML = '';
+        children.forEach(function(child){
+          insertHTML += appendOption(child);
+        });
+        appendChidrenBox(insertHTML);
+      })
+      .fail(function(){
+        alert('カテゴリー取得に失敗しました');
+      })
+    }else{
+      $('#child_category').remove(); //親カテゴリーが初期値になった時、子以下を削除するする
+      $('#grandchild_category').remove(); //子が変更された時、孫以下を削除するする
+    }
+  });
+  // 子カテゴリー選択後のイベント
+  $('#category_area').on('change', '#child_category', function(){
+    var childId = $('#child_category option:selected').val(); //選択された子カテゴリーのidを取得
+    $('#grandchild_category').remove(); //子が変更された時、孫以下を削除するする
+    if (childId != "選択してください"){ //子カテゴリーが初期値でないことを確認
+      $.ajax({
+        url: 'get_category_grandchildren',
+        type: 'GET',
+        data: { child_id: childId },
+        dataType: 'json'
+      })
+      .done(function(grandchildren){
+        if (grandchildren.length != 0) {
+          var insertHTML = '';
+          grandchildren.forEach(function(grandchild){
+            insertHTML += appendOption(grandchild);
+          });
+          appendGrandchidrenBox(insertHTML);
+        }
+      })
+      .fail(function(){
+        alert('カテゴリー取得に失敗しました');
+      })
+    }else{
+      $('#grandchild_category').remove(); //子カテゴリーが初期値になった時、孫以下を削除する
+    }
+  });
+});

--- a/app/assets/stylesheets/modules/_form.scss
+++ b/app/assets/stylesheets/modules/_form.scss
@@ -62,7 +62,7 @@
           display: block;
           width: 200px;
           height: 30px;
-          margin-top: 10px;
+          margin-bottom: 10px;
           margin-right: auto;
           margin-left: auto;
       }

--- a/app/assets/stylesheets/modules/_form.scss
+++ b/app/assets/stylesheets/modules/_form.scss
@@ -23,16 +23,16 @@
       margin-bottom: 10px;
       width: 120px;
 
-     }
+      }
       .item_form_needs{
-       font-size: 10px;
-       color: red; 
-       line-height: 30px;
+        font-size: 10px;
+        color: red; 
+        line-height: 30px;
       }
       .item_form_dont-need{
-       font-size: 10px;
-       color: gray;
-       line-height: 30px;
+        font-size: 10px;
+        color: gray;
+        line-height: 30px;
       }
     }
     //入力欄
@@ -58,6 +58,18 @@
           width: 200px;
           height: 20px;
         }
+      .category{
+          display: block;
+          width: 200px;
+          height: 30px;
+          margin-top: 10px;
+          margin-right: auto;
+          margin-left: auto;
+      }
+    }
+    #category_area{
+      display: block;
+      height: auto;
     }
     //imageBOX
     .post__drop__box__container{
@@ -66,7 +78,7 @@
       display: flex;
       border: 1px dashed #ccc;
 
-   
+
       //プレビュー表示欄
       .prev-content {
         display: flex;
@@ -144,9 +156,7 @@
       }
     }
   }
-
-
- }
+}
 
 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,6 +8,12 @@ class ItemsController < ApplicationController
   def new
     @item = Item.new
     @item.images.build
+    @category_parent_array = []
+    Category.where(ancestry: nil).each do |parent|
+      @category_parent_name_id = [parent.name, parent.id]
+      @category_parent_array << @category_parent_name_id
+    end
+
   end
 
   def create

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,6 +37,13 @@ class ItemsController < ApplicationController
     @items = Item.includes(:images).order("created_at DESC").page(params[:page]).per(12)
   end
 
+  def get_category_children
+    @category_children = Category.find("#{params[:parent_id]}").children
+  end
+
+  def get_category_grandchildren
+    @category_grandchildren = Category.find("#{params[:child_id]}").children
+  end
 
   private
   def item_params

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -30,10 +30,10 @@
         =f.number_field :price, placeholder: "数字を入力",required: true
     #h1.item_form_categoly_id
       #h2.item_form_top_info
-        .item_form_label カテゴリID
+        .item_form_label カテゴリー
         .item_form_needs 必須
-      .input_area
-        =f.number_field :category_id,required: true
+      .input_area#category_area
+        = f.select :category_id, @category_parent_array,{prompt: "選択してください"}, {required: true, class: 'category'}
     #h1.item_form_description
       #h2.item_form_top_info
         .item_form_label 説明

--- a/app/views/items/get_category_children.json.jbuilder
+++ b/app/views/items/get_category_children.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @category_children do |child|
+  json.id child.id
+  json.name child.name
+end

--- a/app/views/items/get_category_grandchildren.json.jbuilder
+++ b/app/views/items/get_category_grandchildren.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @category_grandchildren do |grandchild|
+  json.id grandchild.id
+  json.name grandchild.name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
 
     collection do
       get 'index_more_new_page'
+      get 'get_category_children', defaults: { format: 'json' }
+      get 'get_category_grandchildren', defaults: { format: 'json' }
     end
   end
    


### PR DESCRIPTION
# What
商品出品ページでその商品のカテゴリーが選択できるようにする。
カテゴリは3段階に別れている。
親カテゴリを選択すると、子カテゴリが表示され、
子カテゴリを選択すると、孫カテゴリが表示される。

# Why
商品出品ページでカテゴリ表示ができることはカテゴリ機能において、必要な仕様の為。